### PR TITLE
Icon for the nuget package

### DIFF
--- a/log4net.ElasticSearch.nuspec
+++ b/log4net.ElasticSearch.nuspec
@@ -5,6 +5,7 @@
     <version>0.4.0</version>
     <authors>JP Toto</authors>
     <owners>JP Toto</owners>
+    <iconUrl>http://nest.azurewebsites.net/images/nuget-icon.png</iconUrl>
     <licenseUrl>https://github.com/jptoto/log4net.ElasticSearch/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/jptoto/log4net.ElasticSearch</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
The same as NEST so that when you search for elasticsearch on nuget, this package will look like it's in the NEST family of packages.
