### PR TITLE
Output log events to match default settings on Kibana logstash dashboard

### DIFF
--- a/src/log4net.ElasticSearch/ConnectionBuilder.cs
+++ b/src/log4net.ElasticSearch/ConnectionBuilder.cs
@@ -29,7 +29,7 @@ namespace log4net.ElasticSearch
                 // If the user asked for rolling logs, setup the index by day
                 if (!string.IsNullOrEmpty(lookup["rolling"]))
                     if (lookup["rolling"] == "true")
-                        index = string.Format("{0}-{1}", index, DateTime.Now.ToString("yyyy-MM-dd"));
+                        index = string.Format("{0}-{1}", index, DateTime.Now.ToString("yyyy.MM.dd"));
 
                 return
                     new ConnectionSettings(new Uri(string.Format("http://{0}:{1}", lookup["Server"], 

--- a/src/log4net.ElasticSearch/ElasticSearchAppender.cs
+++ b/src/log4net.ElasticSearch/ElasticSearchAppender.cs
@@ -55,7 +55,7 @@ namespace log4net.ElasticSearch
             logEvent.ThreadName = loggingEvent.ThreadName;
             logEvent.UserName = loggingEvent.UserName;
             logEvent.MessageObject = loggingEvent.MessageObject == null ? "" : loggingEvent.MessageObject.ToString();
-            logEvent.TimeStamp = loggingEvent.TimeStamp;
+            ((IDictionary<string, object>) logEvent).Add("@timestamp", loggingEvent.TimeStamp.ToUniversalTime().ToString("O"));
             logEvent.Exception = loggingEvent.ExceptionObject == null ? "" : loggingEvent.ExceptionObject.ToString();
             logEvent.Message = loggingEvent.RenderedMessage;
             logEvent.Fix = loggingEvent.Fix.ToString();


### PR DESCRIPTION
Hi

Thanks for creating this useful library. I was wondering if you could add support to enable us to use the Kibana Logstash Dashboard without modifications with the logs created by this appender. 

See the diff attached. 

Specifically, the timestamp field is named @timestamp, and the date format on the indiex name is yyyy.MM.dd, not yyyy-MM-dd. If it could be configurable, that is fine of course. 
