### PR TITLE
vagrant setup in order to be able to test it on mono

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ UpgradeLog*.XML
 
 # Nuget file(s)
 *.nupkg
+
+# vagrant...
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.box_url = "https://vagrantcloud.com/ubuntu/boxes/trusty64"
+config.vm.provider "virtualbox" do |v|
+    v.customize ["modifyvm", :id, "--cpus", "2"]
+    v.customize ["modifyvm", :id, "--memory", "1024"]
+  end
+  
+  config.vm.provision :shell, :path => "vagrant/dev-setup.sh"
+
+end

--- a/vagrant/dev-setup.sh
+++ b/vagrant/dev-setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+sudo apt-get install mono-devel mono-xbuild mono-runtime -y
+sudo apt-get install openjdk-7-jre-headless -y
+sudo wget -O - http://packages.elasticsearch.org/GPG-KEY-elasticsearch | sudo apt-key add -
+
+echo "deb http://packages.elasticsearch.org/elasticsearch/1.3/debian stable main" >> /etc/apt/sources.list
+sudo apt-get update
+sudo apt-get install elasticsearch -y
+sudo update-rc.d elasticsearch defaults 95 10
+sudo /etc/init.d/elasticsearch start
+
+echo cd \/vagrant > /home/vagrant/.bashrc


### PR DESCRIPTION
In order to simplify testing on mono you might want something like this.

to build and run do a vagrant ssh and then

```
xbuild src/log4net.ElasticSearch.sln
mono --runtime=v4.0 ./src/packages/xunit.runners.1.9.2/tools/xunit.console.exe ./src/log4net.ElasticSearch.Tests/bin/Debug/log4net.ElasticSearch.Tests.dll
```
