### PR TITLE
Added in branch Feature/roll week month options for different rolling scheme

### DIFF
--- a/src/log4net.ElasticSearch/ExtensionMethods.cs
+++ b/src/log4net.ElasticSearch/ExtensionMethods.cs
@@ -12,6 +12,8 @@ namespace log4net.ElasticSearch
 {
     public static class ExtensionMethods
     {
+        private static readonly JavaScriptSerializer serializer = new JavaScriptSerializer();
+
         public static void Do<T>(this IEnumerable<T> self, Action<T> action)
         {
             foreach (var item in self)
@@ -32,7 +34,7 @@ namespace log4net.ElasticSearch
 
         public static string ToJson<T>(this T self)
         {
-            return new JavaScriptSerializer().Serialize(self);
+            return serializer.Serialize(self);
         }
 
         public static bool Contains(this StringDictionary self, string key)

--- a/src/log4net.ElasticSearch/Models/Uri.cs
+++ b/src/log4net.ElasticSearch/Models/Uri.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using log4net.ElasticSearch.Infrastructure;
+using System.Globalization;
 
 namespace log4net.ElasticSearch.Models
 {


### PR DESCRIPTION
I added some new keys in the connection string to permit differente schemes for rolling indexes,
I also added a static variable for the serializer to avoid to create a new one every time an object is serialized.
