### PR TITLE
Make appender leave numbers as numbers, instead of converting to strings.

### DIFF
--- a/src/log4net.ElasticSearch/ExtensionMethods.cs
+++ b/src/log4net.ElasticSearch/ExtensionMethods.cs
@@ -25,7 +25,7 @@ namespace log4net.ElasticSearch
             return string.Format(self, args);
         }
 
-        public static IEnumerable<KeyValuePair<string, string>> Properties(this LoggingEvent self)
+        public static IEnumerable<KeyValuePair<string, object>> Properties(this LoggingEvent self)
         {
             return self.GetProperties().AsPairs();
         }
@@ -65,14 +65,9 @@ namespace log4net.ElasticSearch
             return parts;
         }
 
-        static IEnumerable<KeyValuePair<string, string>> AsPairs(this ReadOnlyPropertiesDictionary self)
+        static IEnumerable<KeyValuePair<string, object>> AsPairs(this ReadOnlyPropertiesDictionary self)
         {
-            return self.GetKeys().Select(key => Pair.For(key, self[key].ToStringOrNull()));
-        }
-
-        static string ToStringOrNull(this object self)
-        {
-            return self != null ? self.ToString() : null;
+            return self.GetKeys().Select(key => Pair.For(key, self[key]));
         }
 
         static bool IsNullOrEmpty(this string self)

--- a/src/log4net.ElasticSearch/Models/LogEvent.cs
+++ b/src/log4net.ElasticSearch/Models/LogEvent.cs
@@ -15,7 +15,7 @@ namespace log4net.ElasticSearch.Models
     {
         public logEvent()
         {
-            properties = new Dictionary<string, string>();
+            properties = new Dictionary<string, object>();
         }
 
         public string timeStamp { get; set; }
@@ -46,7 +46,7 @@ namespace log4net.ElasticSearch.Models
 
         public string fix { get; set; }
 
-        public IDictionary<string, string> properties { get; set; }
+        public IDictionary<string, object> properties { get; set; }
 
         public string userName { get; set; }
 
@@ -114,9 +114,9 @@ namespace log4net.ElasticSearch.Models
                          Do(pair => logEvent.properties.Add(pair));
         }
 
-        static IEnumerable<KeyValuePair<string, string>> AppenderPropertiesFor(LoggingEvent loggingEvent)
+        static IEnumerable<KeyValuePair<string, object>> AppenderPropertiesFor(LoggingEvent loggingEvent)
         {
-            yield return Pair.For("@timestamp", loggingEvent.TimeStamp.ToUniversalTime().ToString("O"));
+            yield return Pair.For("@timestamp", (object)loggingEvent.TimeStamp.ToUniversalTime().ToString("O"));
         }
     }
 }


### PR DESCRIPTION
This patch allows this appender leave any of the numeric properties as numbers. 

I cloned the latest code, and upon running psake.cmd, the tests fail. Am I doing something wrong? I would like to add proper tests for this change. This path works with our ElasticSearch instance, and it indexes numbers as numbers, so we can run statistics/analysis on those numeric fields.
