### PR TITLE
Changed Uri construction to consider empty typeName

### DIFF
--- a/src/log4net.ElasticSearch/Models/LogEvent.cs
+++ b/src/log4net.ElasticSearch/Models/LogEvent.cs
@@ -9,7 +9,7 @@ namespace log4net.ElasticSearch.Models
     /// <summary>
     /// Primary object which will get serialized into a json object to pass to ES. Deviating from CamelCase
     /// class members so that we can stick with the build in serializer and not take a dependency on another lib. ES
-    /// exepects fields to start with lowercase letters.
+    /// expects fields to start with lowercase letters.
     /// </summary>
     public class logEvent
     {

--- a/src/log4net.ElasticSearch/Models/Uri.cs
+++ b/src/log4net.ElasticSearch/Models/Uri.cs
@@ -3,7 +3,7 @@ using System.Collections.Specialized;
 using log4net.ElasticSearch.Infrastructure;
 
 #if NETFRAMEWORK
-    using System.Web;
+using System.Web;
 #else
     using System.Net;
 #endif          
@@ -14,7 +14,7 @@ namespace log4net.ElasticSearch.Models
     {
         private static string typeName;
         private static string indexNameDateFormat;
-        
+
         readonly StringDictionary connectionStringParts;
 
         static Uri()
@@ -25,10 +25,13 @@ namespace log4net.ElasticSearch.Models
 
         public static void Init(string rollingIndexNameDateFormat, string indexTypeName)
         {
-            typeName = indexTypeName;
+            typeName = string.IsNullOrWhiteSpace(indexTypeName)
+                ? string.Empty
+                : $"/{indexTypeName.Trim()}";
+
             indexNameDateFormat = rollingIndexNameDateFormat;
         }
-        
+
         Uri(StringDictionary connectionStringParts)
         {
             this.connectionStringParts = connectionStringParts;
@@ -38,20 +41,20 @@ namespace log4net.ElasticSearch.Models
         {
             if (!string.IsNullOrWhiteSpace(uri.User()) && !string.IsNullOrWhiteSpace(uri.Password()))
             {
-                #if NETFRAMEWORK
-                    var user = HttpUtility.UrlEncode(uri.User());
-                    var password = HttpUtility.UrlEncode(uri.Password());
-                #else
+#if NETFRAMEWORK
+                var user = HttpUtility.UrlEncode(uri.User());
+                var password = HttpUtility.UrlEncode(uri.Password());
+#else
                     var user = WebUtility.UrlEncode(uri.User());
                     var password = WebUtility.UrlEncode(uri.Password());
-                #endif
-
+#endif
                 return
-                    new System.Uri($"{uri.Scheme()}://{user}:{password}@{uri.Server()}:{uri.Port()}/{uri.Index()}/{typeName}{uri.Routing()}{uri.Bulk()}");
+                    new System.Uri($"{uri.Scheme()}://{user}:{password}@{uri.Server()}:{uri.Port()}/{uri.Index()}{typeName}{uri.Routing()}{uri.Bulk()}");
             }
+
             return string.IsNullOrEmpty(uri.Port())
-                ? new System.Uri($"{uri.Scheme()}://{uri.Server()}/{uri.Index()}/{typeName}{uri.Routing()}{uri.Bulk()}")
-                : new System.Uri($"{uri.Scheme()}://{uri.Server()}:{uri.Port()}/{uri.Index()}/{typeName}{uri.Routing()}{uri.Bulk()}");
+                ? new System.Uri($"{uri.Scheme()}://{uri.Server()}/{uri.Index()}{typeName}{uri.Routing()}{uri.Bulk()}")
+                : new System.Uri($"{uri.Scheme()}://{uri.Server()}:{uri.Port()}/{uri.Index()}{typeName}{uri.Routing()}{uri.Bulk()}");
         }
 
         public static Uri For(string connectionString)


### PR DESCRIPTION
According to Elastic (https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html)
Elastic 7.x: Specifying types in requests is deprecated. For instance, indexing a document no longer requires a document type.
Elastic 8.x: Specifying types in requests is no longer supported.

(cherry picked from commit 378668cf3b930a071bc57967de2b88e8a5c661d7)