### PR TITLE
Fix bug for URI creation when Port not given

### DIFF
--- a/src/log4net.ElasticSearch/Models/Uri.cs
+++ b/src/log4net.ElasticSearch/Models/Uri.cs
@@ -46,8 +46,9 @@ namespace log4net.ElasticSearch.Models
                     var password = WebUtility.UrlEncode(uri.Password());
                 #endif
 
-                return
-                    new System.Uri($"{uri.Scheme()}://{user}:{password}@{uri.Server()}:{uri.Port()}/{uri.Index()}/{typeName}{uri.Routing()}{uri.Bulk()}");
+                return string.IsNullOrEmpty(uri.Port())?
+                    new System.Uri($"{uri.Scheme()}://{user}:{password}@{uri.Server()}:{uri.Port()}/{uri.Index()}/{typeName}{uri.Routing()}{uri.Bulk()}"):
+                    new System.Uri($"{uri.Scheme()}://{user}:{password}@{uri.Server()}/{uri.Index()}/{typeName}{uri.Routing()}{uri.Bulk()}");
             }
             return string.IsNullOrEmpty(uri.Port())
                 ? new System.Uri($"{uri.Scheme()}://{uri.Server()}/{uri.Index()}/{typeName}{uri.Routing()}{uri.Bulk()}")


### PR DESCRIPTION
No additional logif when user/pass given but port not given, resulting in extra colon in the URI to elastic and breaking functionality.

Also, since the bitnami stack for ELK has elasticsearch exposed via /elasticsearch on the 80 port, adding port 80 results in <server root>/elasticsearch:80 instead of <server root>:80/elasticsearch, breaking all of the endpoints.  As bitnami is set to port 80 on default, adding this fix also neatly fixes the issue for anyone trying to use default bitnami settings.